### PR TITLE
Use Haystack docker images to generate schemas

### DIFF
--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -1,40 +1,37 @@
 name: Schemas
+run-name: Update schema for ref ${{ github.event.client_payload.ref || inputs.ref || 'main' }}
 
 on:
-  # Activate this workflow manually
-  workflow_dispatch:
+  workflow_dispatch: # Activate this workflow manually
+    inputs:
+      ref:
+        description: Tag or branch name of Haystack version
+        required: true
+        type: string
+        default: main
 
   # Activate this workflow with an API call
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
   repository_dispatch:
     types: [generate-pipeline-schemas]
 
+env:
+  HAYSTACK_REF: ${{ github.event.client_payload.ref || inputs.ref || 'main' }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 jobs:
 
   run:
+    name: Update schema for ref ${{ github.event.client_payload.ref || inputs.ref || 'main' }}
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-
-      - name: Install system dependencies
-        run: sudo apt update && sudo apt-get install libsndfile1 ffmpeg
-
-      - name: Install Haystack
-        # FIXME: seems like a one-pass install of `[all]` does not work. Thanks `pyworld` :(
-        run: |
-          pip install --upgrade pip
-          pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack
-          pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[all]
-
       - name: Update schema
-        run: python .github/utils/generate_json_schema.py
+        run: |
+          docker run -t -v "${PWD}:/haystack-json-schema" "docker.io/deepset/haystack:base-cpu-${HAYSTACK_REF}" python /haystack-json-schema/.github/utils/generate_json_schema.py
 
       - name: Commit files
         run: |
@@ -42,9 +39,9 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add .
-          git commit -m "Update Schema" -a || echo "No changes to commit"
+          git commit -m "Update Schema for ${HAYSTACK_REF}" -a || echo "No changes to commit"
           git push
-          
+
       - uses: act10ns/slack@v1
         with:
          status: ${{ job.status }}

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -26,14 +26,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Checkout
+      - name: Validate release
+        id: validate
+        continue-on-error: true
+        run: |
+          echo "${HAYSTACK_REF}" | egrep '^main|v[0-9]+\.[0-9]+\.[0-9]+$'
+
+      - if: steps.validate.outcome == 'success'
+        name: Checkout
         uses: actions/checkout@v3
 
-      - name: Update schema
+      - if: steps.validate.outcome == 'success'
+        name: Update schema
         run: |
           docker run -t -v "${PWD}:/haystack-json-schema" "docker.io/deepset/haystack:base-cpu-${HAYSTACK_REF}" python /haystack-json-schema/.github/utils/generate_json_schema.py
 
-      - name: Commit files
+      - if: steps.validate.outcome == 'success'
+        name: Commit files
         run: |
           git status
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -49,4 +58,4 @@ jobs:
         with:
          status: ${{ job.status }}
          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        if: steps.validate.outcome == 'success' && failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Validate release
         id: validate
+        # Silently discard docker releases for test purposes to not publish schema files for them, while avoiding a red CI.
         continue-on-error: true
         run: |
           echo "${HAYSTACK_REF}" | egrep '^main|v[0-9]+\.[0-9]+\.[0-9]+$'

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -39,6 +39,9 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add .
+          if [ "${HAYSTACK_REF}" != "main" ]; then
+            git restore --staged --worktree json-schema/haystack-pipeline-main.schema.json
+          fi
           git commit -m "Update Schema for ${HAYSTACK_REF}" -a || echo "No changes to commit"
           git push
 


### PR DESCRIPTION
Until now, schemas are always generated using the haystack version available in the main branch at the time of the update. There is no way to be explicit about which release to use for schema generation.

In this PR:
- Use the official Haystack docker images to generate the schemas
  - matching the image tag with the desired haystack release (semver or main)
  - making the process more reliable and faster than installing haystack from scratch
- Get the desired haystack version from the dispatch event, either
  - triggered from the haystack repository and including the ref in the payload
  - or running the workflow manually and setting the ref parameter
- Don't commit changes to the main schema unless running for the main ref
  - allowing to update schemas for any releases without changing main

Repository dispatch from haystack will only happen after the Haystack docker images have been successfully released, as proposed in https://github.com/deepset-ai/haystack/pull/3752