### PR TITLE
Add schema for 1.17.1

### DIFF
--- a/json-schema/haystack-pipeline-1.17.1.schema.json
+++ b/json-schema/haystack-pipeline-1.17.1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline-main.schema.json",
+  "$id": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline-1.17.1.schema.json",
   "title": "Haystack Pipeline",
   "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. For more info read the docs at: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
   "type": "object",
@@ -9,7 +9,7 @@
       "title": "Version",
       "description": "Version of the Haystack Pipeline file.",
       "type": "string",
-      "const": "ignore"
+      "const": "1.17.1"
     },
     "extras": {
       "title": "Additional properties group",

--- a/json-schema/haystack-pipeline.schema.json
+++ b/json-schema/haystack-pipeline.schema.json
@@ -450,6 +450,20 @@
           "$ref": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline-1.17.0.schema.json"
         }
       ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "1.17.1"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline-1.17.1.schema.json"
+        }
+      ]
     }
   ],
   "title": "Haystack Pipeline",


### PR DESCRIPTION
Closes https://github.com/deepset-ai/haystack/issues/5102

Job for creating 1.17.1 schema has failed. This PR adds the missing schema.

Ran the following script locally:

```shell
docker run -t -v "${PWD}:/haystack-json-schema" "docker.io/deepset/haystack:base-cpu-v1.17.1" python /haystack-json-schema/.github/utils/generate_json_schema.py
```